### PR TITLE
Wallet flow fixes

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -316,6 +316,10 @@ module.exports = (
         wallet_password: Buffer.from(password, "utf8"),
         cipher_seed_mnemonic: mnemonicPhrase
       };
+
+      // Register user before creating wallet
+      const publicKey = await GunDB.register(alias, password);
+
       walletUnlocker.initWallet(
         walletArgs,
         async (initWalletErr, initWalletResponse) => {
@@ -365,7 +369,6 @@ module.exports = (
                 lightning = lnServices.lightning;
                 walletUnlocker = lnServices.walletUnlocker;
                 const token = await auth.generateToken();
-                const publicKey = await GunDB.register(alias, password);
                 return res.json({
                   mnemonicPhrase: mnemonicPhrase,
                   authorization: token,


### PR DESCRIPTION
This PR fixes issues related to the wallet creation flow `/api/lnd/wallet`.

Now when calling the wallet creation route several checks will run before registering a GunDB user and initializing a new wallet. You'll now have to provide a password that's longer than or equal to 8 characters and the WalletUnlocker service must also be available before calling this route.

Additionally, when calling this route the API will now attempt to register a GunDB user before creating a new wallet instead of doing it the other way around 😄 (#25)